### PR TITLE
chore: update ZenFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@zenfs/core": "^0.17.1",
+    "@zenfs/core": "^1.0.0",
     "@zenfs/dom": "^0.2.15",
     "arg": "^5.0.2",
     "dayjs": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@zenfs/core": "^1.0.0",
-    "@zenfs/dom": "^0.2.15",
+    "@zenfs/dom": "^1.0.0",
     "arg": "^5.0.2",
     "dayjs": "^1.11.13",
     "next": "14.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.1
       '@zenfs/dom':
-        specifier: ^0.2.15
-        version: 0.2.15(@zenfs/core@1.2.1)
+        specifier: ^1.0.0
+        version: 1.0.2(@zenfs/core@1.2.1)
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -641,6 +641,9 @@ packages:
   '@types/semver@7.5.7':
     resolution: {integrity: sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==}
 
+  '@types/wicg-file-system-access@2020.9.8':
+    resolution: {integrity: sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==}
+
   '@typescript-eslint/eslint-plugin@7.13.1':
     resolution: {integrity: sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -737,11 +740,11 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
-  '@zenfs/dom@0.2.15':
-    resolution: {integrity: sha512-Ks1kp1uS9dHuSLfEPA9N4nql7j7zzOhgs2uzerERSVVehNqhhopj8yfCpcX0dlmSGgyC1IC9VkjhiQ2etnn9tA==}
+  '@zenfs/dom@1.0.2':
+    resolution: {integrity: sha512-ozJMf/U7xMw07Dol3LXg+bpCBEyhyr/bW5cbQCZSHIrXpIDZ9Euu3sMM9ydWj4rR6fJjzkpt/IZRUpRVLlfXjQ==}
     engines: {node: '>= 18'}
     peerDependencies:
-      '@zenfs/core': '>=0.17.1'
+      '@zenfs/core': ^1.2.0
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1518,6 +1521,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  fake-indexeddb@6.0.0:
+    resolution: {integrity: sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==}
+    engines: {node: '>=18'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1541,6 +1548,10 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1548,6 +1559,10 @@ packages:
   file-entry-cache@9.1.0:
     resolution: {integrity: sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==}
     engines: {node: '>=18'}
+
+  file-system-access@1.0.4:
+    resolution: {integrity: sha512-JDlhH+gJfZu/oExmtN4/6VX+q1etlrbJbR5uzoBa4BzfTRQbEXGFuGIBRk3ZcPocko3WdEclZSu+d/SByjG6Rg==}
+    engines: {node: '>=14'}
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -2217,6 +2232,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
 
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -3025,6 +3044,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
@@ -3781,6 +3804,9 @@ snapshots:
 
   '@types/semver@7.5.7': {}
 
+  '@types/wicg-file-system-access@2020.9.8':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@7.13.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
@@ -3918,9 +3944,12 @@ snapshots:
       readable-stream: 4.5.2
       utilium: 1.0.4
 
-  '@zenfs/dom@0.2.15(@zenfs/core@1.2.1)':
+  '@zenfs/dom@1.0.2(@zenfs/core@1.2.1)':
     dependencies:
       '@zenfs/core': 1.2.1
+    optionalDependencies:
+      fake-indexeddb: 6.0.0
+      file-system-access: 1.0.4
 
   JSONStream@1.3.5:
     dependencies:
@@ -4888,6 +4917,9 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  fake-indexeddb@6.0.0:
+    optional: true
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -4910,6 +4942,12 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    optional: true
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -4917,6 +4955,15 @@ snapshots:
   file-entry-cache@9.1.0:
     dependencies:
       flat-cache: 5.0.0
+
+  file-system-access@1.0.4:
+    dependencies:
+      '@types/wicg-file-system-access': 2020.9.8
+      fetch-blob: 3.2.0
+      node-domexception: 1.0.0
+    optionalDependencies:
+      web-streams-polyfill: 3.3.3
+    optional: true
 
   fill-range@7.0.1:
     dependencies:
@@ -5555,6 +5602,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-domexception@1.0.0:
+    optional: true
 
   node-releases@2.0.14: {}
 
@@ -6290,6 +6340,9 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+    optional: true
+
+  web-streams-polyfill@3.3.3:
     optional: true
 
   which-boxed-primitive@1.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@zenfs/core':
-        specifier: ^0.17.1
-        version: 0.17.1
+        specifier: ^1.0.0
+        version: 1.2.1
       '@zenfs/dom':
         specifier: ^0.2.15
-        version: 0.2.15(@zenfs/core@0.17.1)
+        version: 0.2.15(@zenfs/core@1.2.1)
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -614,8 +614,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@20.14.8':
-    resolution: {integrity: sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==}
+  '@types/node@20.17.3':
+    resolution: {integrity: sha512-tSQrmKKatLDGnG92h40GD7FzUt0MjahaHwOME4VAFeeA/Xopayq5qLyQRy7Jg/pjgKIFBXuKcGhJo+UdYG55jQ==}
 
   '@types/node@22.5.4':
     resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
@@ -729,8 +729,11 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@zenfs/core@0.17.1':
-    resolution: {integrity: sha512-ceR68eWm+qIPboDUUxXsfzjSwC/M2ZClywTeA6KNs1TvyCyFs2w6n5LYSzrze5hNqR5eK6EZaZKNbvq9acgzeQ==}
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
+  '@zenfs/core@1.2.1':
+    resolution: {integrity: sha512-gtjU1UXXK4nxEAafbaf43l/Ho3St+NVNpNShIyYMAbkWhD+piHwnBHo550b5gFD36m8RjmFzSqQw0VDGGd1cdg==}
     engines: {node: '>= 16'}
     hasBin: true
 
@@ -2926,6 +2929,9 @@ packages:
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
+  tslib@2.8.0:
+    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -2978,9 +2984,6 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -3004,8 +3007,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  utilium@0.4.1:
-    resolution: {integrity: sha512-bYVObnhgSl9PMyE9E89OH6rEzOwSQPZ0TVw1LwgQum1PhL4UxCDTnICcQLhkU9fx/QRQd/wLLcwDfbEsMVkTmg==}
+  utilium@1.0.4:
+    resolution: {integrity: sha512-EGesAFASk3rUTA60heHpw9aspYzRbKe5+3+QO3bS/MoXdEZr0WbMI8SQ6PgI9aEXEUKiKdWnLv4zbArbAW8ohQ==}
 
   valibot@0.32.0:
     resolution: {integrity: sha512-FXBnJl4bNOmeg7lQv+jfvo/wADsRBN8e9C3r+O77Re3dEnDma8opp7p4hcIbF7XJJ30h/5SVohdjer17/sHOsQ==}
@@ -3748,9 +3751,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@20.14.8':
+  '@types/node@20.17.3':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.19.8
 
   '@types/node@22.5.4':
     dependencies:
@@ -3902,19 +3905,22 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@zenfs/core@0.17.1':
+  '@xterm/xterm@5.5.0':
+    optional: true
+
+  '@zenfs/core@1.2.1':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.17.3
       '@types/readable-stream': 4.0.14
       buffer: 6.0.3
       eventemitter3: 5.0.1
       minimatch: 9.0.4
       readable-stream: 4.5.2
-      utilium: 0.4.1
+      utilium: 1.0.4
 
-  '@zenfs/dom@0.2.15(@zenfs/core@0.17.1)':
+  '@zenfs/dom@0.2.15(@zenfs/core@1.2.1)':
     dependencies:
-      '@zenfs/core': 0.17.1
+      '@zenfs/core': 1.2.1
 
   JSONStream@1.3.5:
     dependencies:
@@ -5799,7 +5805,7 @@ snapshots:
     dependencies:
       prettier: 2.8.8
       prettier-package-json: 2.6.0
-      tslib: 2.7.0
+      tslib: 2.8.0
     optionalDependencies:
       eslint: 8.57.0
 
@@ -6187,6 +6193,8 @@ snapshots:
 
   tslib@2.7.0: {}
 
+  tslib@2.8.0: {}
+
   tsutils@3.21.0(typescript@5.5.4):
     dependencies:
       tslib: 1.14.1
@@ -6244,8 +6252,6 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@5.26.5: {}
-
   undici-types@6.19.8: {}
 
   unicorn-magic@0.1.0: {}
@@ -6264,7 +6270,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  utilium@0.4.1: {}
+  utilium@1.0.4:
+    dependencies:
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      '@xterm/xterm': 5.5.0
 
   valibot@0.32.0: {}
 


### PR DESCRIPTION
This PR updates `@zenfs/core` and `@zenfs/dom` to stable versions (`^1.0.0`).